### PR TITLE
feat(serialization): migrate string serialization from deriving to co…

### DIFF
--- a/src/pydjinni/generator/cpp/cpp/config.py
+++ b/src/pydjinni/generator/cpp/cpp/config.py
@@ -74,7 +74,7 @@ class CppConfig(BaseModel):
     )
     not_null: CppNotNull = CppNotNull()
     identifier: CppIdentifier = CppIdentifier()
-    string_serialization_for_enums: bool = Field(
-        default=False,
-        description="Whether to generate ostream << overloads for stringifying enums and flags"
+    string_serialization: bool = Field(
+        default=True,
+        description="Whether to generate `to_string` and `std::formatter` overloads for stringifying records, enums and flags"
     )

--- a/src/pydjinni/generator/cpp/cpp/generator.py
+++ b/src/pydjinni/generator/cpp/cpp/generator.py
@@ -76,7 +76,7 @@ class CppGenerator(Generator):
 
     def generate_enum(self, type_def: Enum):
         self.write_header(Path("header/enum.jinja2.hpp"), type_def=type_def)
-        if self.config.string_serialization_for_enums:
+        if self.config.string_serialization:
             self.write_source(Path("source/enum.jinja2.cpp"), type_def=type_def)
 
     def generate_error_domain(self, type_def: ErrorDomain):
@@ -84,14 +84,14 @@ class CppGenerator(Generator):
 
     def generate_flags(self, type_def: Flags):
         self.write_header(Path("header/flags.jinja2.hpp"), type_def=type_def)
-        if self.config.string_serialization_for_enums:
+        if self.config.string_serialization:
             self.write_source(Path("source/flags.jinja2.cpp"), type_def=type_def)
 
     def generate_record(self, type_def: Record):
         self.write_header(Path("header/record.jinja2.hpp"), type_def=type_def)
         if (Record.Deriving.eq in type_def.deriving
                 or Record.Deriving.ord in type_def.deriving
-                or Record.Deriving.str in type_def.deriving
+                or self.config.string_serialization
                 and type_def.fields):
             self.write_source(Path("source/record.jinja2.cpp"), type_def=type_def)
 

--- a/src/pydjinni/generator/cpp/cpp/templates/header/enum.jinja2.hpp
+++ b/src/pydjinni/generator/cpp/cpp/templates/header/enum.jinja2.hpp
@@ -23,14 +23,14 @@ enum class {{ type_def.cpp.deprecated ~ type_def.cpp.name }} : int {
     {{ item.cpp.name ~ item.cpp.deprecated ~ ("," if not loop.last) }}
 //> endfor
 };
-//> if config.string_serialization_for_enums:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 std::string to_string({{ type_def.cpp.typename }} value) noexcept;
 //> endcall
 //> endif
 //> endblock
 //> block global
-//> if config.string_serialization_for_enums:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 template<>
 struct std::formatter<{{ type_def.cpp.typename }}> : std::formatter<std::string> {

--- a/src/pydjinni/generator/cpp/cpp/templates/header/flags.jinja2.hpp
+++ b/src/pydjinni/generator/cpp/cpp/templates/header/flags.jinja2.hpp
@@ -58,14 +58,14 @@ inline {{ type_def.cpp.name }}& operator^=({{ type_def.cpp.name }}& lhs, {{ type
 constexpr {{ type_def.cpp.name }} operator~({{ type_def.cpp.name }} x) noexcept {
     return static_cast<{{ type_def.cpp.name }}>(~static_cast<unsigned>(x));
 }
-//> if config.string_serialization_for_enums:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 std::string to_string({{ type_def.cpp.typename }} value) noexcept;
 //> endcall
 //> endif
 //> endblock
 //> block global
-//> if config.string_serialization_for_enums:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 template<>
 struct std::formatter<{{ type_def.cpp.typename }}> : std::formatter<std::string> {

--- a/src/pydjinni/generator/cpp/cpp/templates/header/record.jinja2.hpp
+++ b/src/pydjinni/generator/cpp/cpp/templates/header/record.jinja2.hpp
@@ -48,14 +48,14 @@ struct {{ type_def.cpp.deprecated ~ type_def.cpp.name }}{{ " final" if not type_
     friend bool operator>=(const {{ type_def.cpp.name }}& lhs, const {{ type_def.cpp.name }}& rhs);
 //> endif
 };
-//> if 'str' in type_def.deriving:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
-std::string to_string(const {{ type_def.cpp.typename }}& value);
+std::string to_string(const {{ type_def.cpp.derived_name }}& value);
 //> endcall
 //> endif
 //> endblock
 //> block global
-//> if 'str' in type_def.deriving:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 template<>
 struct std::formatter<{{ type_def.cpp.typename }}> : std::formatter<std::string> {

--- a/src/pydjinni/generator/cpp/cpp/templates/source/enum.jinja2.cpp
+++ b/src/pydjinni/generator/cpp/cpp/templates/source/enum.jinja2.cpp
@@ -1,7 +1,7 @@
 /*> extends "base.jinja2" */
 
 //> block content
-//> if config.string_serialization_for_enums:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 std::string to_string({{ type_def.cpp.typename }} value) noexcept {
     switch(value) {

--- a/src/pydjinni/generator/cpp/cpp/templates/source/flags.jinja2.cpp
+++ b/src/pydjinni/generator/cpp/cpp/templates/source/flags.jinja2.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 //> extends "base.jinja2"
 
 //> block content
-//> if config.string_serialization_for_enums:
+//> if config.string_serialization:
 //> call disable_deprecation_warnings(type_def.deprecated)
 std::string to_string({{ type_def.cpp.typename }} value) noexcept {
     std::string output;

--- a/src/pydjinni/generator/cpp/cpp/templates/source/record.jinja2.cpp
+++ b/src/pydjinni/generator/cpp/cpp/templates/source/record.jinja2.cpp
@@ -52,7 +52,7 @@ bool operator>=(const {{ type_def.cpp.name }}& lhs, const {{ type_def.cpp.name }
     return !(lhs < rhs);
 }
 //> endif
-//> if 'str' in type_def.deriving:
+//> if config.string_serialization and not type_def.cpp.base_type:
 //> call disable_deprecation_warnings(type_def.deprecated or (type_def.fields | map(attribute='deprecated') | any))
 std::string to_string(const {{ type_def.cpp.typename }}& value) {
     //> for field in type_def.fields if field.type_ref.optional:

--- a/src/pydjinni/generator/cpp/cpp/type.py
+++ b/src/pydjinni/generator/cpp/cpp/type.py
@@ -240,7 +240,7 @@ class CppSymbolicConstantType(CppBaseType):
     @property
     def header_includes(self) -> set[str]:
         output = super().header_includes
-        if self.config.string_serialization_for_enums:
+        if self.config.string_serialization:
             output.add("<format>")
         if self.decl.deprecated:
             output.add(quote(Path("pydjinni/deprecated.hpp")))
@@ -332,7 +332,7 @@ class CppRecord(CppBaseType):
     @property
     def header_includes(self) -> set[str]:
         includes = super().header_includes | {"<algorithm>"}
-        if Record.Deriving.str in self.decl.deriving:
+        if self.config.string_serialization:
             includes.add("<format>")
         if self.decl.deprecated or any(field.deprecated for field in self.decl.fields):
             includes.add(quote(Path("pydjinni/deprecated.hpp")))
@@ -341,7 +341,7 @@ class CppRecord(CppBaseType):
     @property
     def source_includes(self) -> set[str]:
         includes = super().source_includes
-        if Record.Deriving.str in self.decl.deriving:
+        if self.config.string_serialization:
             includes.add("<string>")
         return includes
 

--- a/src/pydjinni/generator/cpp/target.py
+++ b/src/pydjinni/generator/cpp/target.py
@@ -24,4 +24,4 @@ class CppTarget(Target):
     key = "cpp"
     display_key = "C++"
     generators = [CppGenerator]
-    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord, Record.Deriving.str}
+    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord}

--- a/src/pydjinni/generator/cppcli/cppcli/config.py
+++ b/src/pydjinni/generator/cppcli/cppcli/config.py
@@ -49,4 +49,8 @@ class CppCliConfig(BaseModel):
         default=True,
         description="Whether diagnostics nullability attributes should be added to methods, functions and fields (Not available in .NET Framework)"
     )
+    string_serialization: bool = Field(
+        default=True,
+        description="Whether to generate `ToString` overloads for records"
+    )
     identifier: CppCliIdentifierStyle = CppCliIdentifierStyle()

--- a/src/pydjinni/generator/cppcli/cppcli/templates/header/record.jinja2.hpp
+++ b/src/pydjinni/generator/cppcli/cppcli/templates/header/record.jinja2.hpp
@@ -43,7 +43,7 @@ public:
         {{ field.cppcli.typename }} get();
     }
     //> endfor
-    //> if 'str' in type_def.deriving:
+    //> if config.string_serialization:
 
     System::String^ ToString() override;
     //> endif

--- a/src/pydjinni/generator/cppcli/cppcli/templates/source/record.jinja2.cpp
+++ b/src/pydjinni/generator/cppcli/cppcli/templates/source/record.jinja2.cpp
@@ -92,7 +92,7 @@ int {{ type_def.cppcli.name }}::CompareTo({{ type_def.cppcli.name }}^ other)
     return 0;
 }
 //> endif
-//> if 'str' in type_def.deriving:
+//> if config.string_serialization:
 
 System::String^ {{ type_def.cppcli.name }}::ToString()
 {

--- a/src/pydjinni/generator/cppcli/target.py
+++ b/src/pydjinni/generator/cppcli/target.py
@@ -24,4 +24,4 @@ class CppCliTarget(Target):
     key = "cppcli"
     display_key = "C++/CLI"
     generators = [CppCliGenerator]
-    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord, Record.Deriving.str}
+    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord}

--- a/src/pydjinni/generator/it/enum/CMakeLists.txt
+++ b/src/pydjinni/generator/it/enum/CMakeLists.txt
@@ -20,5 +20,5 @@ define_test_case(EnumTest
         src/helper.cpp
     OPTIONS
         generate.cpp.namespace=test::enum_test
-        generate.cpp.string_serialization_for_enums=True
+        generate.cpp.string_serialization=True
 )

--- a/src/pydjinni/generator/it/flags/CMakeLists.txt
+++ b/src/pydjinni/generator/it/flags/CMakeLists.txt
@@ -20,5 +20,5 @@ define_test_case(FlagsTest
         src/helper.cpp
     OPTIONS
         generate.cpp.namespace=test::flags_test
-        generate.cpp.string_serialization_for_enums=True
+        generate.cpp.string_serialization=True
 )

--- a/src/pydjinni/generator/it/record/record.pydjinni
+++ b/src/pydjinni/generator/it/record/record.pydjinni
@@ -8,7 +8,7 @@ primitive_types = record {
     double_t: f64;
     string_t: string;
     date_t: date;
-} deriving (str, eq)
+} deriving (eq)
 
 collection_types = record {
     int_list: list<i32>;
@@ -19,12 +19,12 @@ collection_types = record {
 
     int_int_map: map<i32, i32>;
     string_string_map: map<string, string>;
-} deriving (str)
+}
 
 optional_types = record {
     int_optional: i32?;
     string_optional: string?;
-} deriving (str)
+}
 
 binary_types = record {
     binary_t: binary;
@@ -38,11 +38,11 @@ base_record = record +any {
 nested_type = record {
     a: i32;
     b: list<list<i32>>;
-} deriving (str)
+}
 
 parent_type = record {
     nested: nested_type;
-} deriving (str)
+}
 
 helper = main interface +cpp {
     static get_primitive_types(record_type: primitive_types) -> primitive_types;
@@ -59,7 +59,7 @@ helper = main interface +cpp {
 old_record = record {
     # more comment
     a: bool;
-} deriving (str)
+}
 
 deprecated_field_record = record {
     # @deprecated the field is old
@@ -67,4 +67,4 @@ deprecated_field_record = record {
     # foo
     # @deprecated this is optional and old
     older: i32?;
-} deriving (str)
+}

--- a/src/pydjinni/generator/java/java/config.py
+++ b/src/pydjinni/generator/java/java/config.py
@@ -103,4 +103,8 @@ class JavaConfig(BaseModel):
         default="Functional",
         description="Prefix for generated functional interfaces."
     )
+    string_serialization: bool = Field(
+        default=True,
+        description="Whether to generate `toString` overloads for records"
+    )
     identifier: JavaIdentifierStyle = JavaIdentifierStyle()

--- a/src/pydjinni/generator/java/java/templates/record.jinja2.java
+++ b/src/pydjinni/generator/java/java/templates/record.jinja2.java
@@ -87,7 +87,7 @@ limitations under the License.
         return 0;
     }
 //> endif
-//> if 'str' in type_def.deriving
+//> if config.string_serialization
 
     @Override
     public String toString() {

--- a/src/pydjinni/generator/java/target.py
+++ b/src/pydjinni/generator/java/target.py
@@ -27,4 +27,4 @@ class JavaTarget(Target):
     key = "java"
     display_key = "Java"
     generators = [JavaGenerator, JniGenerator]
-    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord, Record.Deriving.str}
+    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord}

--- a/src/pydjinni/generator/objc/objc/config.py
+++ b/src/pydjinni/generator/objc/objc/config.py
@@ -64,5 +64,9 @@ class ObjcConfig(BaseModel):
         default=False,
         description="All generated `@protocol` will implement `<NSObject>`"
     )
+    string_serialization: bool = Field(
+        default=True,
+        description="Whether to generate `description` overloads for records"
+    )
     swift: SwiftConfig = SwiftConfig()
     identifier: ObjcIdentifierStyle = ObjcIdentifierStyle()

--- a/src/pydjinni/generator/objc/objc/templates/source/record.jinja2.m
+++ b/src/pydjinni/generator/objc/objc/templates/source/record.jinja2.m
@@ -87,7 +87,7 @@ limitations under the License.
 }
 //> endif
 
-//> if 'str' in type_def.deriving:
+//> if config.string_serialization:
 - (NSString *)description {
     return [NSString stringWithFormat:@"<%@
     /*>- for field in type_def.fields -*/

--- a/src/pydjinni/generator/objc/target.py
+++ b/src/pydjinni/generator/objc/target.py
@@ -27,4 +27,4 @@ class ObjcTarget(Target):
     key = "objc"
     display_key = "Objective-C"
     generators = [ObjcGenerator, ObjcppGenerator]
-    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord, Record.Deriving.str}
+    supported_deriving = {Record.Deriving.eq, Record.Deriving.ord}

--- a/src/pydjinni/parser/ast.py
+++ b/src/pydjinni/parser/ast.py
@@ -96,9 +96,6 @@ class Record(ClassType):
         Ordering comparison.
         Is not supported for collection types, optionals, and booleans.
         """
-        str = 'str', """
-        String representation of a record instance (for debugging or logging).
-        """
 
     primitive: BaseExternalType.Primitive = BaseExternalType.Primitive.record
     fields: list[DataField] = []

--- a/tests/parser/test_parser_record.py
+++ b/tests/parser/test_parser_record.py
@@ -48,7 +48,6 @@ def test_parsing_record(tmp_path: Path):
 @pytest.mark.parametrize("deriving,expected", [
     ('eq', {Record.Deriving.eq}),
     ('eq, ord', {Record.Deriving.eq, Record.Deriving.ord}),
-    ('eq, ord, str', {Record.Deriving.eq, Record.Deriving.ord, Record.Deriving.str}),
     ('eq, eq', {Record.Deriving.eq})
 ])
 def test_parsing_record_deriving(tmp_path: Path, deriving, expected: set[Record.Deriving]):
@@ -86,7 +85,7 @@ def test_parsing_record_unknown_deriving(tmp_path: Path):
     ('', {Record.Deriving.eq, Record.Deriving.ord}),
     ('deriving()', {Record.Deriving.eq, Record.Deriving.ord}),
     ('deriving(ord)', {Record.Deriving.eq, Record.Deriving.ord}),
-    ('deriving(eq, ord, str)', {Record.Deriving.eq, Record.Deriving.ord, Record.Deriving.str}),
+    ('deriving(eq, ord)', {Record.Deriving.eq, Record.Deriving.ord}),
 ])
 def test_parsing_record_default_deriving(tmp_path: Path, deriving, expected: set[Record.Deriving]):
     reader, resolver_mock = given_mocks()


### PR DESCRIPTION
…nfig option

defining string serialization as deriving wasn't consistent with enums an flags, which would either need to have their own serialization switch, or generate the to_string functions on demand.